### PR TITLE
Update rdm6300.rst

### DIFF
--- a/components/binary_sensor/rdm6300.rst
+++ b/components/binary_sensor/rdm6300.rst
@@ -68,7 +68,7 @@ unsigned integer.
         then:
           - mqtt.publish:
               topic: rdm6300/tag
-              payload: !lambda 'return uint32_to_string(x);'
+              payload: !lambda 'return str_sprintf("%u", x);'
 
 A tag scanned event can also be sent to the Home Assistant tag component
 using :ref:`api-homeassistant_tag_scanned_action`.
@@ -79,7 +79,7 @@ using :ref:`api-homeassistant_tag_scanned_action`.
       # ...
       on_tag:
         then:
-          - homeassistant.tag_scanned: !lambda 'return uint32_to_string(x);'
+          - homeassistant.tag_scanned: !lambda 'return str_sprintf("%u", x);'
 
 .. _rdm6300-tag:
 

--- a/components/binary_sensor/rdm6300.rst
+++ b/components/binary_sensor/rdm6300.rst
@@ -68,7 +68,7 @@ unsigned integer.
         then:
           - mqtt.publish:
               topic: rdm6300/tag
-              payload: !lambda 'return str_sprintf("%u", x);'
+              payload: !lambda 'return to_string(x);'
 
 A tag scanned event can also be sent to the Home Assistant tag component
 using :ref:`api-homeassistant_tag_scanned_action`.
@@ -79,7 +79,7 @@ using :ref:`api-homeassistant_tag_scanned_action`.
       # ...
       on_tag:
         then:
-          - homeassistant.tag_scanned: !lambda 'return str_sprintf("%u", x);'
+          - homeassistant.tag_scanned: !lambda 'return to_string(x);'
 
 .. _rdm6300-tag:
 


### PR DESCRIPTION
return uint32_to_string(x);
This function was removed in esphome/esphome#3009

## Description:


**Related issue (if applicable):** fixes <link to issue>

**Pull request in [esphome](https://github.com/esphome/esphome) with YAML changes (if applicable):** esphome/esphome#<esphome PR number goes here>

## Checklist:

  - [ ] Branch: `next` is for changes and new documentation that will go public with the next ESPHome release. Fixes, changes and adjustments for the current release should be created against `current`.
  - [ ] Link added in `/index.rst` when creating new documents for new components or cookbook.
